### PR TITLE
add use figmaAPI example

### DIFF
--- a/components/Panel.tsx
+++ b/components/Panel.tsx
@@ -8,6 +8,7 @@ import {
 import React from "react";
 import { Textarea } from "./ui/textarea";
 import { Button } from "./ui/button";
+import { figmaAPI } from "@/lib/figmaAPI";
 
 function Panel() {
   const [loading, setLoading] = React.useState(false);
@@ -17,17 +18,16 @@ function Panel() {
   const [svgContent, setSvgContent] = React.useState("");
 
   // pass the result to figma
-  const onPasteSVGIntoFigma = () => {
-    parent.postMessage(
-      {
-        pluginMessage: {
-          type: "paste-svg",
-          svg: svgContent,
-        },
-        pluginId: "*",
-      },
-      "*"
-    );
+  const onPasteSVGIntoFigma = async () => {
+    const result = await figmaAPI.run((figma, params) => {
+      const { svg } = params;
+      const newSVGNode = figma.createNodeFromSvg(svg);
+      figma.currentPage.appendChild(newSVGNode);
+      figma.currentPage.selection = [newSVGNode];
+      return { nodeId: newSVGNode.id }
+    }, { svg: svgContent });
+
+    console.log(`nodeId: ${result.nodeId}`);
   };
 
   const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));

--- a/plugin/code.ts
+++ b/plugin/code.ts
@@ -6,7 +6,24 @@ figma.showUI(`<script>window.location.href = '${SITE_URL}'</script>`, {
 });
 
 figma.ui.onmessage = (msg) => {
-  if (msg.type === "paste-svg") {
+  if (msg.type === "EVAL") {
+    const { code, id, params } = msg;
+    try {
+      const fn = eval(code);
+      const result = fn(figma, params);
+      figma.ui.postMessage({
+        type: "EVAL_RESULT",
+        id,
+        result,
+      });
+    } catch (error) {
+      figma.ui.postMessage({
+        type: "EVAL_REJECT",
+        id,
+        error: (error as Error).message,
+      });
+    }
+  } else if (msg.type === "paste-svg") {
     const newSVGNode = figma.createNodeFromSvg(msg.svg);
     figma.currentPage.appendChild(newSVGNode);
     figma.currentPage.selection = [newSVGNode];


### PR DESCRIPTION
This pull request includes updates to add example to use `figmaAPI`.

### Updates to `Panel` component:

* [`components/Panel.tsx`](diffhunk://#diff-615307b3ba5db49b4805692a44ec75908d139d14d7a22fec8b25eda1edb4cf8dR11): Added `figmaAPI` import and refactored `onPasteSVGIntoFigma` to demonstrate how to use the `figmaAPI` module to interact with Figma's API

### Updates to plugin message handling:

* [`plugin/code.ts`](diffhunk://#diff-116f2f002312e3c39f74b31945f095cefd6664ad67b57a4cf96ba761256e9a64L9-R26): Introduced a new message type `EVAL` to evaluate code dynamically within the Figma environment. This includes handling for successful evaluations (`EVAL_RESULT`) and errors (`EVAL_REJECT`). The existing `paste-svg` message handling remains unchanged but is now secondary to the new `EVAL` message type.